### PR TITLE
bug fix: Call to undefined function Hyperf\XxlJob\Listener\retry()

### DIFF
--- a/src/Listener/MainWorkerStartListener.php
+++ b/src/Listener/MainWorkerStartListener.php
@@ -26,6 +26,8 @@ use Hyperf\XxlJob\Exception\XxlJobException;
 use Hyperf\XxlJob\Logger\JobExecutorFileLogger;
 use Throwable;
 
+use function Hyperf\Support\retry;
+
 class MainWorkerStartListener implements ListenerInterface
 {
     public function __construct(


### PR DESCRIPTION
[WARNING] Error: Call to undefined function Hyperf\XxlJob\Listener\retry() in /home/sparklee/code/hyperf/vendor/hyperf/xxl-job-incubator/src/Listener/MainWorkerStartListener.php:84 Stack trace:
#0 /home/sparklee/code/hyperf/runtime/container/proxy/Hyperf_Coroutine_Coroutine.proxy.php(82): Hyperf\XxlJob\Listener\MainWorkerStartListener->Hyperf\XxlJob\Listener\{closure}() #1 [internal function]: Hyperf\Coroutine\Coroutine::Hyperf\Coroutine\{closure}() #2 {main}