### PR TITLE
bug fix: swoole 环境下使用 process 进程模式无法执行超过 60 秒的耗时定时任务

### DIFF
--- a/src/Run/JobRun.php
+++ b/src/Run/JobRun.php
@@ -96,7 +96,7 @@ class JobRun
         Coroutine::create(function () use ($command, $request) {
             $filename = $this->config->getLogFileDir() . sprintf('jobId_%s_logId_%s.info', $request->getJobId(), $request->getLogId());
             $executorTimeout = $request->getExecutorTimeout();
-            $process = new Process($command, null, null, null, $executorTimeout > 0 ? $executorTimeout : null);
+            $process = new Process($command, timeout: $executorTimeout > 0 ? $executorTimeout : null);
             $process->start();
             $data['logId'] = $request->getLogId();
             $data['logDateTime'] = $request->getLogDateTime();

--- a/src/Run/JobRun.php
+++ b/src/Run/JobRun.php
@@ -94,7 +94,8 @@ class JobRun
         $this->stdoutLogger->debug('XXL-JOB execute commands:' . implode(' ', $command));
         Coroutine::create(function () use ($command, $request) {
             $filename = $this->config->getLogFileDir() . sprintf('jobId_%s_logId_%s.info', $request->getJobId(), $request->getLogId());
-            $process = new Process($command);
+            $executorTimeout = $request->getExecutorTimeout();
+            $process = new Process($command, null, null, null, $executorTimeout > 0 ? $executorTimeout : null);
             $process->start();
             $data['logId'] = $request->getLogId();
             $data['logDateTime'] = $request->getLogDateTime();


### PR DESCRIPTION
【问题】：xxl-job-incubator 在 swoole 环境下默认使用 process 进程模式执行定时任务，其使用 Symfony Process 类创建进程，Process 类的构建函数的最后一个参数 timeout 超时时间默认写死为 60 秒，xxl-job-incubator 在使用 new Process($command) 构建进程时使用了默认的 timeout，当定时任务执行时间超过 60 秒时，进程自动退出，导致定时任务无法执行完成。

【解决】：将在 xxl-job-admin 管理后台配置的”任务超时时间“传递给 Process 类的 timeout 参数，若”任务超时时间“为0，即永不超时，则传 null 给 timeout，表示禁用超时功能。

【参考】：Symfony Process 构建函数：
// $timeout The timeout in seconds or null to disable public function __construct(array $command, string $cwd = null, array $env = null, mixed $input = null, ?float $timeout = 60)）